### PR TITLE
week4 &3 project

### DIFF
--- a/index-data.sh
+++ b/index-data.sh
@@ -4,8 +4,11 @@ usage()
   exit 2
 }
 
-PRODUCTS_JSON_FILE="/workspace/search_with_machine_learning_course/opensearch/bbuy_products.json"
-QUERIES_JSON_FILE="/workspace/search_with_machine_learning_course/opensearch/bbuy_queries.json"
+# PRODUCTS_JSON_FILE="/workspace/search_with_machine_learning_course/opensearch/bbuy_products.json"
+# QUERIES_JSON_FILE="/workspace/search_with_machine_learning_course/opensearch/bbuy_queries.json"
+
+PRODUCTS_JSON_FILE="/workspace/search_with_machine_learning_course/week4/conf/bbuy_products.json"
+QUERIES_JSON_FILE="/workspace/search_with_machine_learning_course/week4/conf/bbuy_queries.json"
 
 PRODUCTS_LOGSTASH_FILE="/workspace/search_with_machine_learning_course/logstash/index-bbuy.logstash"
 QUERIES_LOGSTASH_FILE="/workspace/search_with_machine_learning_course/logstash/index-bbuy-queries.logstash"

--- a/opensearch/bbuy_products.json
+++ b/opensearch/bbuy_products.json
@@ -1,465 +1,409 @@
 {
-    "settings": {
-        "index": {
-            "refresh_interval": "5s"
+  "settings": {
+    "index.refresh_interval": "5s",
+    "analysis": {
+      "analyzer": {
+        "smarter_hyphens": {
+          "tokenizer": "smarter_hyphens_tokenizer",
+          "filter": [
+            "smarter_hyphens_filter",
+            "lowercase"
+          ]
         }
       },
-    "mappings" : {
-      "properties" : {
-        "@timestamp" : {
-          "type" : "date"
-        },
-        "@version" : {
-          "type" : "integer"
-        },
-        "name" : {
-          "type" : "text",
-          "analyzer": "english",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+      "tokenizer": {
+        "smarter_hyphens_tokenizer": {
+          "type": "char_group",
+          "tokenize_on_chars": [
+            "whitespace",
+            "\n"
+          ]
+        }
+      },
+      "filter": {
+        "smarter_hyphens_filter": {
+          "type": "word_delimiter_graph",
+          "catenate_words": true,
+          "catenate_all": true
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "@version": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "sku" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "accessories": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          },
+          "long": {
+            "type": "long",
+            "ignore_malformed": true
           }
-        },
-        "shortDescription" : {
-          "type" : "text",
-          "analyzer": "english",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "active": {
+        "type": "boolean"
+      },
+      "bestBuyItemId": {
+        "type": "keyword"
+      },
+      "bestSellingRank": {
+        "type": "long"
+      },
+      "categoryPath": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
           }
-        },
-        "longDescription" : {
-          "type" : "text",
-          "analyzer": "english",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "categoryPathIds": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
           }
-        },
-        "department" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "categoryLeaf": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
           }
-        },
-        "regularPrice" : {
-          "type" : "float"
-        },
-        "accessories" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "class": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
           }
-        },
-        "active" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "classId": {
+        "type": "integer"
+      },
+      "color": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "bestBuyItemId" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "condition": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "bestSellingRank" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "customerReviewAverage": {
+        "type": "float"
+      },
+      "customerReviewCount": {
+        "type": "integer"
+      },
+      "department": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
           }
-        },
-        "categoryLeaf" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "departmentId": {
+        "type": "integer"
+      },
+      "depth": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "categoryPath" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "digital": {
+        "type": "boolean"
+      },
+      "features": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
           }
-        },
-        "categoryPathCount" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "frequentlyPurchasedWith": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "long": {
+            "type": "long"
           }
-        },
-        "categoryPathIds" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "height": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "class" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "homeDelivery": {
+        "type": "boolean"
+      },
+      "host": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "classId" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "image": {
+        "type": "keyword"
+      },
+      "inStoreAvailability": {
+        "type": "boolean"
+      },
+      "inStorePickup": {
+        "type": "boolean"
+      },
+      "longDescription": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "longDescriptionHtml": {
+        "type": "keyword"
+      },
+      "manufacturer": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 1024
           }
-        },
-        "color" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "message": {
+        "type": "text"
+      },
+      "modelNumber": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "condition" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          },
+          "hyphens": {
+            "type": "text",
+            "analyzer": "smarter_hyphens"
+          },
+          "suggest": {
+            "type": "completion"
           }
-        },
-        "customerReviewAverage" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+
+        }
+      },
+      "onSale": {
+        "type": "boolean"
+      },
+      "onlineAvailability": {
+        "type": "boolean"
+      },
+      "path": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "customerReviewCount" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "productId": {
+        "type": "long"
+      },
+      "product_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "departmentId" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "quantityLimit": {
+        "type": "integer"
+      },
+      "regularPrice": {
+        "type": "float"
+      },
+      "relatedProducts": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "long": {
+            "type": "long"
           }
-        },
-        "depth" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "releaseDate": {
+        "type": "date"
+      },
+      "salePrice": {
+        "type": "float"
+      },
+      "salesRankLongTerm": {
+        "type": "long"
+      },
+      "salesRankMediumTerm": {
+        "type": "long"
+      },
+      "salesRankShortTerm": {
+        "type": "long"
+      },
+      "shipping": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "digital" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "shippingCost": {
+        "type": "float"
+      },
+      "shippingWeight": {
+        "type": "float"
+      },
+      "shortDescription": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "shortDescriptionHtml": {
+        "type": "keyword"
+      },
+      "sku": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "features" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "startDate": {
+        "type": "date"
+      },
+      "subclass": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "frequentlyPurchasedWith" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "subclassId": {
+        "type": "long"
+      },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "height" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "type": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "homeDelivery" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "url": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
           }
-        },
-        "image" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "weight": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "inStoreAvailability" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "inStorePickup" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "longDescriptionHtml" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "manufacturer" : {
-          "type" : "text",
-          "analyzer": "english",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "modelNumber" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "onSale" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "onlineAvailability" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "productId" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "quantityLimit" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "relatedProducts" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "releaseDate" : {
-          "type" : "date"
-        },
-        "salePrice" : {
-          "type" : "float"
-        },
-        "salesRankLongTerm" : {
-          "type" : "long"
-        },
-        "salesRankMediumTerm" : {
-          "type" : "long"
-        },
-        "salesRankShortTerm" : {
-          "type" : "long"
-        },
-        "shippingCost" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "shippingWeight" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "shortDescriptionHtml" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "startDate" : {
-          "type" : "date"
-        },
-        "subclass" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "subclassId" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "tags" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "type" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "url" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "weight" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
-          }
-        },
-        "width" : {
-          "type" : "text",
-          "fields" : {
-            "keyword" : {
-              "type" : "keyword",
-              "ignore_above" : 256
-            }
+        }
+      },
+      "width": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
         }
       }
     }
-}
+  }
+} 

--- a/opensearch/bbuy_queries.json
+++ b/opensearch/bbuy_queries.json
@@ -1,45 +1,69 @@
 {
-  "settings": {
-      "index:"{
-        "refresh_interval": "5s"
-    }
-  },
-  "mappings":{
+    "settings": {
+      "index.refresh_interval": "5s"
+    },
+    "mappings": {
       "properties": {
-          "@timestamp" : {
-              "type" : "date"
-            },
-          "@version" : {
-              "type" : "long"
-          },
-          "category":{
-              "type":"keyword",
-              "ignore_above":256
-          },
-          "click_time":{
-              "type":"date",
-              "format":"yyyy-MM-dd HH:mm:ss.SSS||ordinal_date_time||strict_date_optional_time||epoch_millis"
-          },
-          "query":{
-              "type":"text",
-              "fields":{
-                  "keyword":{
-                      "type":"keyword",
-                      "ignore_above":256
-                  }
-              }
-          },
-          "query_time":{
-              "type":"date",
-              "format":"yyyy-MM-dd HH:mm:ss.SSS||ordinal_date_time||strict_date_optional_time||epoch_millis"
-          },
-          "sku":{
-              "type":"long"
-          },
-          "user":{
-              "type":"keyword",
-              "ignore_above":256
+        "@timestamp": {
+          "type": "date"
+        },
+        "@version": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
           }
+        },
+        "category": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "click_time": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss.S||yyyy-MM-dd HH:mm:ss.SS||yyyy-MM-dd HH:mm:ss.SSSZ||yyyy-MM-dd HH:mm:ss.SSS||yyyy-MM-dd HH:mm:ssZ||yyyy-MM-dd||epoch_millis||strict_date_optional_time"
+        },
+        "query": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "stemmed": {
+              "type": "text",
+              "analyzer": "english"
+            }
+          }
+        },
+        "query_time": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss.S||yyyy-MM-dd HH:mm:ss.SS||yyyy-MM-dd HH:mm:ss.SSSZ||yyyy-MM-dd HH:mm:ss.SSS||yyyy-MM-dd HH:mm:ssZ||yyyy-MM-dd||epoch_millis||strict_date_optional_time"
+        },
+        "sku": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "user": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
       }
+    }
   }
-}

--- a/week3/documents.py
+++ b/week3/documents.py
@@ -7,6 +7,8 @@ from flask import (
 )
 import fasttext
 import json
+from nltk import word_tokenize
+
 
 bp = Blueprint('documents', __name__, url_prefix='/documents')
 
@@ -26,5 +28,15 @@ def annotate():
                 if item == "name":
                     if syns_model is not None:
                         print("IMPLEMENT ME: call nearest_neighbors on your syn model and return it as `name_synonyms`")
+                        tokens = word_tokenize(the_text)
+                        syns_ret = []
+
+                        for token in tokens:
+                            cleaned_text = token.strip().lower()
+                        for item in syns_model.get_nearest_neighbors(cleaned_text):
+                            if "name_synonyms" not in response:
+                                response["name_synonyms"] = []
+                            if(item[0] > 0.9):
+                                response["name_synonyms"].append(item[1])
         return jsonify(response)
     abort(415)

--- a/week3/extractTitles.py
+++ b/week3/extractTitles.py
@@ -3,6 +3,9 @@ import random
 import xml.etree.ElementTree as ET
 import argparse
 from pathlib import Path
+import nltk
+from nltk.stem import SnowballStemmer
+import string
 
 directory = r'/workspace/search_with_machine_learning_course/data/pruned_products'
 parser = argparse.ArgumentParser(description='Process some integers.')
@@ -26,7 +29,16 @@ if args.input:
 sample_rate = args.sample_rate
 
 def transform_training_data(name):
-    # IMPLEMENT
+    clean = name.lower().translate(str.maketrans(string.punctuation, ' '*len(string.punctuation)))
+    encoded_string = clean.encode("ascii", "ignore")
+    decode_string = encoded_string.decode()
+    stemmer = SnowballStemmer("english")
+    words = decode_string.split()  
+    stem_words = []
+    for w in words:
+        x = stemmer.stem(w)
+        stem_words.append(x)
+    name = " ".join(stem_words)  
     return name.replace('\n', ' ')
 
 # Directory for product data

--- a/week4/__init__.py
+++ b/week4/__init__.py
@@ -12,7 +12,8 @@ def create_app(test_config=None):
     if test_config is None:
         # load the instance config, if it exists, when not testing
         app.config.from_pyfile('config.py', silent=True)
-        QUERY_CLASS_MODEL_LOC = os.environ.get("QUERY_CLASS_MODEL_LOC", "/workspace/datasets/fasttext/query_model.bin")
+        # QUERY_CLASS_MODEL_LOC = os.environ.get("QUERY_CLASS_MODEL_LOC", "/workspace/datasets/fasttext/query_model.bin")
+        QUERY_CLASS_MODEL_LOC = os.environ.get("QUERY_CLASS_MODEL_LOC", "/workspace/datasets/labeled_query_data_min_count_100_epoch_20.model.bin")
         if QUERY_CLASS_MODEL_LOC and os.path.isfile(QUERY_CLASS_MODEL_LOC):
             app.config["query_model"] = fasttext.load_model(QUERY_CLASS_MODEL_LOC)
         else:

--- a/week4/create_labeled_queries.py
+++ b/week4/create_labeled_queries.py
@@ -72,19 +72,18 @@ df["query"] = df['query'].apply(transform)
 if min_queries > 1:
     grp_df = df.groupby(['category']).size().to_frame('size')
 
+    prune_count_left = len(grp_df[grp_df["size"] < min_queries])
 
-    rem_prune_count = len(grp_df[grp_df["size"] < min_queries])
-
-    while rem_prune_count > 0:
+    while prune_count_left > 0:
         items = grp_df[grp_df["size"] < min_queries]
-        ct = 0
+        c = 0
         for i,row in items.iterrows():
             df["category"].replace({i:get_parent(i, parents_df)}, inplace=True)
-            print(f"Replacing for {i} #{ct}/{rem_prune_count}")
-            ct = ct + 1
+            print(f"Replacing for {i} #{ct}/{prune_count_left}")
+            c = c + 1
         grp_df = df.groupby(['category']).size().to_frame('size')
-        rem_prune_count = len(grp_df[grp_df["size"] < min_queries])
-        print(f"Remaining to prune {rem_prune_count}")
+        prune_count_left = len(grp_df[grp_df["size"] < min_queries])
+        print(f"Remaining to prune {prune_count_left}")
         print(f"Unique Categories now {len(grp_df)}")
 
 # Create labels in fastText format.

--- a/week4/create_labeled_queries.py
+++ b/week4/create_labeled_queries.py
@@ -7,6 +7,7 @@ import csv
 
 # Useful if you want to perform stemming.
 import nltk
+from nltk.tokenize import RegexpTokenizer
 stemmer = nltk.stem.PorterStemmer()
 
 categories_file_name = r'/workspace/datasets/product_data/categories/categories_0001_abcat0010000_to_pcmcat99300050000.xml'
@@ -49,8 +50,42 @@ df = pd.read_csv(queries_file_name)[['category', 'query']]
 df = df[df['category'].isin(categories)]
 
 # IMPLEMENT ME: Convert queries to lowercase, and optionally implement other normalization, like stemming.
+def transform(q):
+    q = q.lower()
+    tokenizer = RegexpTokenizer(r'\w+')
+    parts = tokenizer.tokenize(q)
+    parts = [stemmer.stem(p) for p in parts]
+    parts = [p.strip() for p in parts]
+    return " ".join(parts)
+
+
+def get_parent(cat, leaf_df):
+    if cat == "cat00000":
+        return "cat00000"
+    else:
+        return parents_df[parents_df["category"]==cat]["parent"].iloc[0]
+
+df["query"] = df['query'].apply(transform)
+
 
 # IMPLEMENT ME: Roll up categories to ancestors to satisfy the minimum number of queries per category.
+if min_queries > 1:
+    grp_df = df.groupby(['category']).size().to_frame('size')
+
+
+    rem_prune_count = len(grp_df[grp_df["size"] < min_queries])
+
+    while rem_prune_count > 0:
+        items = grp_df[grp_df["size"] < min_queries]
+        ct = 0
+        for i,row in items.iterrows():
+            df["category"].replace({i:get_parent(i, parents_df)}, inplace=True)
+            print(f"Replacing for {i} #{ct}/{rem_prune_count}")
+            ct = ct + 1
+        grp_df = df.groupby(['category']).size().to_frame('size')
+        rem_prune_count = len(grp_df[grp_df["size"] < min_queries])
+        print(f"Remaining to prune {rem_prune_count}")
+        print(f"Unique Categories now {len(grp_df)}")
 
 # Create labels in fastText format.
 df['label'] = '__label__' + df['category']

--- a/week4/search.py
+++ b/week4/search.py
@@ -73,8 +73,7 @@ def get_query_category(user_query, query_class_model):
     user_query = clean_query(user_query, simple=True)
     predicted_categories, confidence = query_class_model.predict(user_query, 5)
     categories += [
-        (category.replace("__label__", ""), confidence)
-        for category, confidence in zip(predicted_categories, confidence)
+        (category.replace("__label__", ""), confidence) for category, confidence in zip(predicted_categories, confidence)
     ]
     return categories
 

--- a/week4/search.py
+++ b/week4/search.py
@@ -71,10 +71,10 @@ def get_query_category(user_query, query_class_model):
     # print("IMPLEMENT ME: get_query_category")
     categories = []
     user_query = clean_query(user_query, simple=True)
-    predicted_cats, confidence = query_class_model.predict(user_query, 5)
+    predicted_categories, confidence = query_class_model.predict(user_query, 5)
     categories += [
         (category.replace("__label__", ""), confidence)
-        for category, confidence in zip(predicted_cats, confidence)
+        for category, confidence in zip(predicted_categories, confidence)
     ]
     return categories
 

--- a/week4/templates/display_results.jinja2
+++ b/week4/templates/display_results.jinja2
@@ -9,6 +9,8 @@
         {% endif %}
       </div>
       <div><span class="search-result-header">ID</span>: {{ hit._source.productId[0] }}</div>
+      <div><span class="search-result-header">Categories</span>: {{ hit._source.categoryPath }}</div>
+      <div><span class="search-result-header">Category IDs</span>: {{ hit._source.categoryPathIds }}</div>
       <div><span class="search-result-header">Description</span>:
         {% if hit._source.longDescription %}
           {#do we have a highlight?#}

--- a/week4/utilities/query_utils.py
+++ b/week4/utilities/query_utils.py
@@ -1,5 +1,17 @@
 import math
 # some helpful tools for dealing with queries
+
+def add_filter(query_obj, query_categories):
+
+    query_obj["query"]["bool"]["filter"] = [{
+        "terms": {
+            "categoryPathIds.keyword": query_categories
+        }
+    }]
+
+    return 
+
+    
 def create_stats_query(aggs, extended=True):
     print("Creating stats query from %s" % aggs)
     agg_map = {}

--- a/week4/utilities/query_utils.py
+++ b/week4/utilities/query_utils.py
@@ -1,17 +1,6 @@
 import math
 # some helpful tools for dealing with queries
 
-def add_filter(query_obj, query_categories):
-
-    query_obj["query"]["bool"]["filter"] = [{
-        "terms": {
-            "categoryPathIds.keyword": query_categories
-        }
-    }]
-
-    return 
-
-    
 def create_stats_query(aggs, extended=True):
     print("Creating stats query from %s" % aggs)
     agg_map = {}


### PR DESCRIPTION
WEEK 4:
1. For query classification:

    -   How many unique categories did you see in your rolled up training data when you set the minimum number of queries per category to 100? To 1000?
        - For 100 minimum number of queries unique categories -- I saw around 870 unique categories
        - For 500 minimum number of queries unique categories -- I saw around 541 unique categories
        - For 1000 minimum number of queries unique categories -- I saw around 385 unique categories
    - What values did you achieve for P@1, R@3, and R@5? You should have tried at least a few different models, varying the minimum number of queries per category as well as trying different fastText parameters or query normalization. Report at least 3 of your runs.
    - 
| Min Queries      | 100 | 500 | 1000 |
| ----------- | ----------- | ----------- |----------- |
| P@1            | 0.519           | 0.52            | 0.528   |
| R@1            | 0.519          |  0.52            | 0.528    |
| P@3           | 0.232          |  0.235         | 0.237    |
| R@3            | 0.697         |  0.704          | 0.71      |
| P@5            | 0.152          |   0.153         | 0.155      |
| R@5            | 0.758         |   0.765         | 0.774     |


2. For integrating query classification with search: 
     - Give 2 or 3 examples of queries where you saw a dramatic positive change in the results because of filtering. Make sure to include the classifier output for those queries.
     - Given 2 or 3 examples of queries where filtering hurt the results, either because the classifier was wrong or for some other reason. Again, include the classifier output for those queries.
     
     I did write the code for this, but unfortunately unable to test it as I keep getting the error 
```
opensearchpy.exceptions.RequestError: RequestError(400, 'search_phase_execution_exception', 'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [image] in order to load field data by uninverting the inverted index. Note that this can use significant memory.')
```

Tried different troubleshooting ways, but couldn't solve it. 

Week3:

- For classifying product names to categories:
  - What precision (P@1) were you able to achieve?
    -  Started with [N       9945, P@1     0.533, R@1     0.533]
    - Ended with [N       45000, P@1     0.947, R@1     0.947] with minimum products = 200
  - What fastText parameters did you use?
    - used epochs -- (10,25, 50), wordNgrams -- (1,2) and learning rate(lr) -- (0.1,0.3,1) 
  - How did you transform the product names?
    - lowercase, strip text, punctuations removed, used stemming with snowball stemmer.
  - How did you prune infrequent category labels, and how did that affect your precision?
    - used category minimum count of 10, 50, 100, 200 
  - How did you prune the category tree, and how did that affect your precision?
    - precision increased as the depth of category decreased
-  For deriving synonyms from content:
  - What 20 tokens did you use for evaluation?
    - Due to lack of time used only 5 -- ``` headphones, sony, iphone, thinkpad, black ```
  - What fastText parameters did you use?
    -  `min_count`
  - How did you transform the product names?
    - Lowercase and strip text, punctuation removed, new line char removed,  
  - What threshold score did you use? -- 0.5, 0.9
  - What synonyms did you obtain for those tokens? 
```
Query word? headphones
headphon 0.982952
bud 0.901313
earbud 0.870792
ear 0.867881
skullcandi 0.836928
akg 0.831247
earphon 0.831223
nois 0.823636
sennheis 0.818025
isol 0.783753
---
Query word? sony
sono 0.892902
so 0.832328
song 0.813055
sonax 0.808274
songbook 0.787641
adult 0.785212
alfr 0.764992
various 0.761709
sonicar 0.758427
sonic 0.748386
---
Query word? thinkpad
ibm 0.929424
lenovo 0.915594
latitud 0.898124
i3 0.879704
ideapad 0.872292
obsidian 0.863913
laptop 0.833553
i5 0.831567
lithium 0.822413
lenmar 0.819815
---
Query word? black
blackjack 0.691082
blackhawk 0.645199
</s> 0.635778
blackberri 0.595096
blade 0.583555
white 0.566877
silver 0.522024
with 0.506986
gel 0.505375
blue 0.504001
---
Query word? iphone
3gs 0.873182
iphon 0.866746
phone 0.862073
smartphon 0.857279
3g 0.856249
droid 0.825385
otterbox 0.82377
ifrogz 0.823489
commut 0.818656
silicon 0.817464        
```
- For integrating synonyms with search:
  - How did you transform the product names (if different than previously)? -- Same as above 
  - What threshold score did you use? - 0.5 & 0.9
  - Were you able to find the additional results by matching synonyms?
